### PR TITLE
Add specialist course creation workflow

### DIFF
--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -48,6 +48,56 @@ input,select,textarea{padding:10px 12px;border:1px solid #cbd5e1;border-radius:1
 .person-row{display:flex;align-items:center;gap:12px}
 .person-actions{display:flex;align-items:center;justify-content:space-between;font-size:14px;font-weight:600;color:var(--primary)}
 .person-actions .icon{width:16px;height:16px}
+.course-card{position:relative;overflow:hidden}
+.course-card-header{position:relative}
+.course-thumb{border-radius:12px;background-size:cover;background-position:center;height:160px;position:relative;overflow:hidden;display:grid;place-items:center;padding:12px;text-align:center;color:var(--muted);border:1px solid rgba(0,0,0,.08)}
+.course-thumb-placeholder{font-weight:600}
+.course-count{position:absolute;left:12px;bottom:12px;background:rgba(0,0,0,.75);color:#fff;padding:4px 10px;border-radius:999px;font-size:12px;font-weight:600}
+.price-tag{position:absolute;top:12px;right:12px;background:var(--primary);color:#fff;padding:6px 12px;border-radius:999px;font-weight:700;box-shadow:0 8px 16px rgba(0,0,0,.2)}
+.hover-video{position:absolute;inset:0;opacity:0;transition:opacity .2s ease}
+.hover-video video{width:100%;height:100%;object-fit:cover;border-radius:inherit}
+.course-card:hover .hover-video{opacity:1}
+.preview-info{display:grid;gap:4px}
+.preview-title{font-weight:700;font-size:14px;color:var(--primary)}
+.muted.small{font-size:13px}
+.stack-sm{display:grid;grid-template-columns:repeat(auto-fit,minmax(220px,1fr));gap:16px}
+.file-field small{display:block;margin-top:6px}
+.course-manage{display:grid;gap:16px}
+.course-manage-header{display:flex;align-items:flex-start;justify-content:space-between;gap:16px;flex-wrap:wrap}
+.course-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(220px,1fr));gap:16px}
+.course-card-mini{display:grid;gap:10px;padding:12px;border:1px solid rgba(0,0,0,.08);border-radius:14px;background:rgba(0,0,0,.02)}
+.course-card-mini .course-thumb{height:140px}
+.course-card-mini.compact{padding:8px}
+.course-card-mini.compact .course-thumb{height:120px}
+.course-info h4{margin:0;font-size:16px}
+.course-info p{margin:0;font-size:13px}
+.course-empty{text-align:center;padding:32px 16px;border:1px dashed var(--accent);border-radius:16px;color:var(--muted)}
+.profile-note{background:rgba(0,0,0,.04);padding:10px 12px;border-radius:12px;font-size:14px}
+.course-form{display:grid;gap:18px}
+.file-pair{align-items:start}
+.videos-block{display:grid;gap:12px}
+.videos-head{display:flex;justify-content:space-between;align-items:center;gap:12px;flex-wrap:wrap}
+.video-items{display:grid;gap:12px}
+.video-item{border:1px solid rgba(0,0,0,.08);border-radius:14px;padding:12px;display:grid;gap:12px;background:rgba(0,0,0,.02);position:relative}
+.video-item .remove-video{align-self:flex-end;background:transparent;border:none;color:var(--danger);font-weight:600;cursor:pointer}
+.video-item .remove-video:hover{color:#ff1744}
+.videos-block .small{font-size:13px}
+.course-detail{display:grid;gap:16px;margin-bottom:24px}
+.course-detail-header{display:grid;gap:16px;grid-template-columns:minmax(200px,260px) 1fr;align-items:start}
+.course-detail-cover{position:relative;border-radius:16px;background-size:cover;background-position:center;min-height:180px;overflow:hidden;border:1px solid rgba(0,0,0,.1)}
+.course-detail-meta h3{margin:0}
+.course-detail-meta p{margin:6px 0 0}
+.course-player{display:grid;gap:12px}
+.course-player video{width:100%;border-radius:16px;max-height:380px;background:#000}
+.player-controls label{display:flex;gap:8px;align-items:center;font-weight:600}
+.player-controls select{min-width:140px}
+.playlist{list-style:none;margin:0;padding:0;display:grid;gap:8px}
+.playlist-item{display:flex;gap:12px;align-items:center;padding:10px 12px;border-radius:12px;border:1px solid rgba(0,0,0,.12);cursor:pointer;transition:background .2s ease,border .2s ease}
+.playlist-item.active{border-color:var(--primary);background:rgba(27,179,74,.12)}
+.playlist-item:hover{border-color:var(--primary)}
+.playlist-index{width:26px;height:26px;border-radius:999px;background:var(--primary);color:#fff;display:grid;place-items:center;font-weight:700}
+.playlist-title{font-weight:600}
+.course-placeholder{padding:48px 16px;text-align:center;border:1px dashed var(--accent);border-radius:16px;color:var(--muted);font-weight:600}
 .chat-box{display:flex;flex-direction:column;gap:8px}
 .chat-box .messages{flex:1;overflow:auto;max-height:65vh}
 .send.sticky{position:sticky;bottom:0;background:var(--card);padding-top:8px}
@@ -79,8 +129,6 @@ input,select,textarea{padding:10px 12px;border:1px solid #cbd5e1;border-radius:1
 .file-row{display:flex;align-items:center;gap:12px;flex-wrap:wrap}
 .form-actions{display:flex;gap:12px;justify-content:flex-end;flex-wrap:wrap}
 .course-preview{display:grid;gap:12px}
-.course-image{border-radius:16px;min-height:180px;background-size:cover;background-position:center;border:1px solid rgba(0,0,0,.1)}
-.course-placeholder{padding:48px 16px;text-align:center;border:1px dashed var(--accent);border-radius:16px;color:var(--muted);font-weight:600}
 .profile-overview{display:grid;gap:6px}
 .profile-overview p{margin:0}
 .profile-public{display:grid;grid-template-columns:repeat(auto-fit,minmax(260px,1fr));gap:16px;align-items:start}
@@ -89,3 +137,8 @@ input,select,textarea{padding:10px 12px;border:1px solid #cbd5e1;border-radius:1
 html[data-theme="dark"] .nav-link:hover{background:rgba(255,255,255,.08)}
 html[data-theme="dark"] .profile-tabs .tab{background:rgba(255,255,255,.08)}
 html[data-theme="dark"] .profile-tabs .tab:hover{background:rgba(255,255,255,.14)}
+html[data-theme="dark"] .course-card-mini{background:rgba(255,255,255,.04);border-color:rgba(255,255,255,.12)}
+html[data-theme="dark"] .course-thumb{border-color:rgba(255,255,255,.1)}
+html[data-theme="dark"] .profile-note{background:rgba(255,255,255,.06)}
+html[data-theme="dark"] .video-item{background:rgba(255,255,255,.04);border-color:rgba(255,255,255,.12)}
+html[data-theme="dark"] .playlist-item{border-color:rgba(255,255,255,.12)}

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -36,4 +36,117 @@
       if(!menu.contains(evt.target)) close();
     });
   }
+
+  const videoForm = document.querySelector('[data-video-list]');
+  if(videoForm){
+    const itemsWrap = videoForm.querySelector('.video-items');
+    const tpl = document.getElementById('videoItemTemplate');
+    const addBtn = videoForm.querySelector('[data-video-add]');
+    const updateRemoveState = ()=>{
+      const items = itemsWrap.querySelectorAll('[data-video-item]');
+      items.forEach((item, idx)=>{
+        const removeBtn = item.querySelector('[data-video-remove]');
+        const fileInput = item.querySelector('input[type="file"]');
+        if(removeBtn){
+          removeBtn.style.display = items.length <= 1 ? 'none' : '';
+        }
+        if(fileInput){
+          fileInput.required = idx === 0;
+        }
+      });
+    };
+    const bindRemove = (node)=>{
+      const btn = node.querySelector('[data-video-remove]');
+      if(btn){
+        btn.addEventListener('click', ()=>{
+          const siblings = itemsWrap.querySelectorAll('[data-video-item]');
+          if(siblings.length <= 1) return;
+          node.remove();
+          updateRemoveState();
+        });
+      }
+    };
+    const addItem = ()=>{
+      if(!tpl) return;
+      const clone = tpl.content.firstElementChild.cloneNode(true);
+      itemsWrap.appendChild(clone);
+      bindRemove(clone);
+      updateRemoveState();
+    };
+    itemsWrap.querySelectorAll('[data-video-item]').forEach(item=> bindRemove(item));
+    updateRemoveState();
+    if(addBtn){
+      addBtn.addEventListener('click', ()=>{
+        addItem();
+      });
+    }
+    if(!itemsWrap.querySelector('[data-video-item]')){
+      addItem();
+    }
+  }
+
+  document.querySelectorAll('[data-preview-hover]').forEach(box=>{
+    const video = box.querySelector('video');
+    if(!video) return;
+    let timer;
+    box.addEventListener('mouseenter', ()=>{
+      clearTimeout(timer);
+      video.currentTime = 0;
+      video.play().catch(()=>{});
+    });
+    box.addEventListener('mouseleave', ()=>{
+      timer = setTimeout(()=>{
+        video.pause();
+        try{ video.currentTime = 0; }catch(e){}
+      }, 80);
+    });
+  });
+
+  document.querySelectorAll('[data-course-player]').forEach(player=>{
+    const video = player.querySelector('[data-video]') || player.querySelector('video');
+    const qualitySelect = player.querySelector('[data-quality-select]');
+    const playlist = Array.from(player.querySelectorAll('[data-playlist] .playlist-item'));
+    if(!video || !playlist.length) return;
+    const sourceEl = video.querySelector('source');
+    const setSource = src => {
+      if(sourceEl){
+        sourceEl.src = src;
+      }
+      video.src = src;
+      video.load();
+    };
+    const loadSources = sources => {
+      if(!sources || !sources.length) return;
+      if(qualitySelect){
+        qualitySelect.innerHTML = '';
+        sources.forEach((s, idx)=>{
+          const opt = document.createElement('option');
+          opt.value = s.src;
+          opt.textContent = s.quality;
+          if(idx===0) opt.selected = true;
+          qualitySelect.appendChild(opt);
+        });
+      }
+      setSource(sources[0].src);
+    };
+    playlist.forEach(item=>{
+      item.addEventListener('click', ()=>{
+        playlist.forEach(p=>p.classList.remove('active'));
+        item.classList.add('active');
+        const sources = JSON.parse(item.dataset.sources || '[]');
+        const poster = item.dataset.poster;
+        if(poster){ video.setAttribute('poster', poster); }
+        loadSources(sources);
+      });
+    });
+    if(qualitySelect){
+      qualitySelect.addEventListener('change', evt=>{
+        const src = evt.target.value;
+        setSource(src);
+        video.play().catch(()=>{});
+      });
+    }
+    const initialSources = JSON.parse(playlist[0].dataset.sources || '[]');
+    loadSources(initialSources);
+  });
 })();

--- a/templates/course_form.html
+++ b/templates/course_form.html
@@ -1,0 +1,92 @@
+{% extends "base.html" %}
+{% block title %}Добавить курс{% endblock %}
+{% block content %}
+<h1><span class="icon icon-profile"></span>Добавить курс</h1>
+<form class="card course-form" method="post" enctype="multipart/form-data" id="courseForm">
+  <div class="grid-2 stack-sm">
+    <label class="field">
+      <span>Заголовок *</span>
+      <input name="title" value="{{ form.title }}" placeholder="Например, React с нуля" required>
+    </label>
+    <label class="field">
+      <span>Цена интенсива *</span>
+      <input name="price" value="{{ form.price }}" placeholder="3500" inputmode="decimal" required>
+    </label>
+    <label class="field">
+      <span>Предмет</span>
+      <input name="subject" value="{{ form.subject }}" placeholder="Направление или предмет">
+    </label>
+    <label class="field">
+      <span>Тема (можно пропустить)</span>
+      <input name="topic" value="{{ form.topic }}" placeholder="Тема курса">
+    </label>
+  </div>
+  <label class="field">
+    <span>Описание</span>
+    <textarea name="description" rows="4" placeholder="Расскажите, чему научится студент и кому подойдёт курс">{{ form.description }}</textarea>
+  </label>
+  <div class="grid-2 stack-sm file-pair">
+    <label class="field file-field">
+      <span>Изображение интенсива *</span>
+      <input type="file" name="cover_image" accept="image/*" required>
+      <small class="muted">Добавьте яркую обложку, которая появится в поиске.</small>
+    </label>
+    <label class="field file-field">
+      <span>Видео-превью (необязательно)</span>
+      <input type="file" name="preview_clip" accept="video/*">
+      <small class="muted">Короткое превью, которое воспроизводится при наведении.</small>
+    </label>
+  </div>
+  <div class="videos-block" data-video-list>
+    <div class="videos-head">
+      <h3>Видео материалы</h3>
+      <button class="btn outline" type="button" data-video-add>Добавить видео</button>
+    </div>
+    <p class="muted small">Если видео весит слишком много, разделите его на несколько частей и загрузите их отдельно.</p>
+    <div class="video-items">
+      {% for meta in form.video_meta %}
+      <div class="video-item" data-video-item>
+        <div class="grid-2 stack-sm">
+          <label class="field">
+            <span>Название видео</span>
+            <input name="video_title[]" value="{{ meta.title }}" placeholder="Урок {{ loop.index }}">
+          </label>
+          <label class="field">
+            <span>Качество</span>
+            <input name="video_quality[]" value="{{ meta.quality }}" placeholder="Например, 1080p">
+          </label>
+        </div>
+        <label class="field file-field">
+          <span>Файл</span>
+          <input type="file" name="video_file[]" accept="video/*" {% if loop.first %}required{% endif %}>
+        </label>
+        <button class="remove-video" type="button" data-video-remove>Удалить видео</button>
+      </div>
+      {% endfor %}
+    </div>
+  </div>
+  <div class="form-actions">
+    <a class="btn outline" href="{{ url_for('profile', tab='course') }}">Отмена</a>
+    <button class="btn strong" type="submit">Сохранить курс</button>
+  </div>
+</form>
+<template id="videoItemTemplate">
+  <div class="video-item" data-video-item>
+    <div class="grid-2 stack-sm">
+      <label class="field">
+        <span>Название видео</span>
+        <input name="video_title[]" placeholder="Новый урок">
+      </label>
+      <label class="field">
+        <span>Качество</span>
+        <input name="video_quality[]" placeholder="Например, 720p">
+      </label>
+    </div>
+    <label class="field file-field">
+      <span>Файл</span>
+      <input type="file" name="video_file[]" accept="video/*" required>
+    </label>
+    <button class="remove-video" type="button" data-video-remove>Удалить видео</button>
+  </div>
+</template>
+{% endblock %}

--- a/templates/profile.html
+++ b/templates/profile.html
@@ -39,6 +39,10 @@
       <input name="nickname" value="{{ user.nickname or '' }}" placeholder="@nickname">
     </label>
     <label class="field">
+      <span>Ник в Telegram</span>
+      <input name="telegram" value="{{ user.telegram or '' }}" placeholder="@telegram" required>
+    </label>
+    <label class="field">
       <span>Возраст</span>
       <input name="age" value="{{ user.age or '' }}" placeholder="18" inputmode="numeric">
     </label>
@@ -58,45 +62,81 @@
     </label>
     <span class="muted">Форматы: png, jpg, jpeg, gif, webp</span>
   </div>
+  <div class="profile-note">
+    <strong>Почта:</strong> {{ user.email }} <span class="muted">(видно только вам)</span>
+  </div>
   <div class="form-actions">
     <button class="btn strong" type="submit">Сохранить</button>
     <button class="btn outline" type="submit" name="cancel" value="1">Отмена</button>
   </div>
 </form>
 {% elif tab == 'course' %}
-<form class="card profile-form" method="post" enctype="multipart/form-data">
-  <input type="hidden" name="action" value="course">
-  <div class="course-preview">
-    {% if user.course_image %}
-      <div class="course-image" style="background-image:url('{{ user.course_image }}')"></div>
-    {% else %}
-      <div class="course-placeholder">Курса пока нет</div>
-    {% endif %}
+<section class="card course-manage">
+  <div class="course-manage-header">
+    <div>
+      <h3>Мои интенсивы</h3>
+      <p class="muted">Добавьте курс с подробным описанием, видео и обложкой.</p>
+    </div>
+    <a class="btn strong" href="{{ url_for('course_create') }}">Добавить курс</a>
   </div>
-  <label class="file-btn">
-    <span class="btn outline">Загрузить изображение курса</span>
-    <input type="file" name="course_image" accept="image/*">
-  </label>
-  <div class="form-actions">
-    <button class="btn strong" type="submit">Сохранить</button>
-    <button class="btn outline" type="submit" name="cancel" value="1">Отмена</button>
+  {% if courses %}
+  <div class="course-grid">
+    {% for item in courses %}
+      {% set course = item.course %}
+      <div class="course-card-mini">
+        <div class="course-thumb" {% if course.cover_image %}style="background-image:url('{{ course.cover_image }}')"{% endif %}>
+          {% if item.video_count %}
+          <span class="course-count">{{ item.video_count }} видео</span>
+          {% endif %}
+          {% if course.price is not none %}
+          <span class="price-tag">{{ format_price(course.price) }}</span>
+          {% endif %}
+        </div>
+        <div class="course-info">
+          <h4>{{ course.title }}</h4>
+          <p class="muted">{{ course.subject or 'Без предмета' }}{% if course.topic %} · {{ course.topic }}{% endif %}</p>
+        </div>
+      </div>
+    {% endfor %}
   </div>
-</form>
+  {% else %}
+  <div class="course-empty">
+    <p>Курсы пока не добавлены.</p>
+    <a class="btn outline" href="{{ url_for('course_create') }}">Создать первый курс</a>
+  </div>
+  {% endif %}
+</section>
 {% else %}
 <section class="card profile-overview">
   <h3>О себе</h3>
   <p>Имя: <strong>{{ user.first_name or '—' }}</strong></p>
   <p>Фамилия: <strong>{{ user.last_name or '—' }}</strong></p>
   <p>Ник: <strong>@{{ user.nickname or '—' }}</strong></p>
+  <p>Телеграм: <strong>{{ user.telegram or '—' }}</strong></p>
   <p>Возраст: <strong>{{ user.age or '—' }}</strong></p>
   <p>Образование: <strong>{{ user.education or '—' }}</strong></p>
   <p>Год выпуска: <strong>{{ user.graduation_year or '—' }}</strong></p>
+  <p>Почта: <strong>{{ user.email }}</strong> <span class="muted">(видно только вам)</span></p>
   <div class="course-preview">
-    <h3>Мой курс</h3>
-    {% if user.course_image %}
-      <div class="course-image" style="background-image:url('{{ user.course_image }}')"></div>
+    <h3>Мои интенсивы</h3>
+    {% if courses %}
+    <div class="course-grid">
+      {% for item in courses %}
+        {% set course = item.course %}
+        <div class="course-card-mini compact">
+          <div class="course-thumb" {% if course.cover_image %}style="background-image:url('{{ course.cover_image }}')"{% endif %}>
+            {% if item.video_count %}<span class="course-count">{{ item.video_count }} видео</span>{% endif %}
+            {% if course.price is not none %}<span class="price-tag">{{ format_price(course.price) }}</span>{% endif %}
+          </div>
+          <div class="course-info">
+            <h4>{{ course.title }}</h4>
+            <p class="muted">{{ course.subject or 'Без предмета' }}{% if course.topic %} · {{ course.topic }}{% endif %}</p>
+          </div>
+        </div>
+      {% endfor %}
+    </div>
     {% else %}
-      <div class="course-placeholder">Курса пока нет</div>
+    <div class="course-placeholder">Курсы пока не добавлены.</div>
     {% endif %}
   </div>
 </section>

--- a/templates/search.html
+++ b/templates/search.html
@@ -8,15 +8,48 @@
 </form>
 <div class="grid-cards">
   {% for p in people %}
-  <a class="card person" href="{{ url_for('public_profile', user_id=p.id) }}">
+  {% set preview_course = p.courses|last %}
+  <a class="card person course-card" href="{{ url_for('public_profile', user_id=p.id) }}">
+    <div class="course-card-header">
+      <div class="course-thumb" {% if preview_course and preview_course.cover_image %}style="background-image:url('{{ preview_course.cover_image }}')"{% endif %}>
+        {% if not preview_course or not preview_course.cover_image %}
+        <span class="course-thumb-placeholder">Превью появится после публикации</span>
+        {% endif %}
+        {% if preview_course and preview_course.preview_clip %}
+        <div class="hover-video" data-preview-hover>
+          <video src="{{ preview_course.preview_clip }}" muted loop preload="metadata" {% if preview_course.cover_image %}poster="{{ preview_course.cover_image }}"{% endif %}></video>
+        </div>
+        {% endif %}
+        {% if preview_course and preview_course.videos %}
+        <span class="course-count">{{ preview_course.videos|length }} видео</span>
+        {% endif %}
+      </div>
+      {% if preview_course and preview_course.price is not none %}
+      <span class="price-tag">{{ format_price(preview_course.price) }}</span>
+      {% endif %}
+    </div>
     <div class="person-row">
       <img class="avatar-mini" src="{{ avatar_url(p) }}" alt="{{ p.nickname or p.first_name }}">
       <div>
         <div class="p-name">{{ p.first_name or 'Без имени' }} {{ p.last_name or '' }}</div>
-        <div class="muted">@{{ p.nickname or 'без_ника' }} · {{ 'Специалист' if p.role=='specialist' else 'Ученик' }}</div>
+        <div class="muted">@{{ p.nickname or 'без_ника' }}</div>
       </div>
     </div>
-    <div class="tags">{{ p.specialist.keywords if p.specialist else (p.student.looking_for if p.student else '') }}</div>
+    <div class="tags">
+      {% if preview_course %}
+        {{ preview_course.subject or 'Без предмета' }}{% if preview_course.topic %} · {{ preview_course.topic }}{% endif %}
+      {% else %}
+        {{ p.specialist.keywords if p.specialist else (p.student.looking_for if p.student else '') }}
+      {% endif %}
+    </div>
+    <div class="preview-info">
+      {% if preview_course %}
+      <div class="preview-title">Превью курса</div>
+      <div class="muted small">{{ preview_course.title }}</div>
+      {% else %}
+      <div class="muted small">Специалист ещё не добавил курс.</div>
+      {% endif %}
+    </div>
     <div class="person-actions">
       <span>Перейти к профилю</span>
       <svg class="icon" viewBox="0 0 24 24" aria-hidden="true"><path d="m9 5 7 7-7 7-1.41-1.41L13.17 12 7.59 6.41 9 5Z"/></svg>

--- a/templates/user_public.html
+++ b/templates/user_public.html
@@ -13,13 +13,69 @@
     <p>Возраст: {{ person.age or '—' }}</p>
     <p>Образование: {{ person.education or '—' }}</p>
     <p>Год выпуска: {{ person.graduation_year or '—' }}</p>
+    <p>Телеграм: {{ person.telegram or '—' }}</p>
   </div>
   <div class="card public-right">
-    <h2>Мой курс</h2>
-    {% if person.course_image %}
-      <div class="course-image" style="background-image:url('{{ person.course_image }}')"></div>
+    <h2>Курсы</h2>
+    {% if courses %}
+      {% for data in courses %}
+        {% set course = data.course %}
+        <article class="course-detail" data-course-player>
+          <header class="course-detail-header">
+            <div class="course-detail-cover" {% if course.cover_image %}style="background-image:url('{{ course.cover_image }}')"{% endif %}>
+              {% if data.video_total %}
+              <span class="course-count">{{ data.video_total }} видео</span>
+              {% endif %}
+              {% if course.price is not none %}
+              <span class="price-tag">{{ format_price(course.price) }}</span>
+              {% endif %}
+              {% if course.preview_clip %}
+              <div class="hover-video" data-preview-hover>
+                <video src="{{ course.preview_clip }}" muted loop preload="metadata" {% if course.cover_image %}poster="{{ course.cover_image }}"{% endif %}></video>
+              </div>
+              {% endif %}
+            </div>
+            <div class="course-detail-meta">
+              <h3>{{ course.title }}</h3>
+              <div class="muted">{{ course.subject or 'Без предмета' }}{% if course.topic %} · {{ course.topic }}{% endif %}</div>
+              {% if course.description %}<p>{{ course.description }}</p>{% endif %}
+            </div>
+          </header>
+          {% if data.lessons %}
+          <div class="course-player" data-player>
+            <video controls preload="metadata" data-video {% if course.cover_image %}poster="{{ course.cover_image }}"{% endif %}>
+              {% set first_lesson = data.lessons[0] %}
+              {% set first_source = first_lesson.sources[0] %}
+              <source src="{{ first_source.src }}">
+            </video>
+            <div class="player-controls">
+              <label>Качество
+                <select data-quality-select>
+                  {% for source in first_lesson.sources %}
+                  <option value="{{ source.src }}">{{ source.quality }}</option>
+                  {% endfor %}
+                </select>
+              </label>
+            </div>
+            <ul class="playlist" data-playlist>
+              {% for lesson in data.lessons %}
+              <li class="playlist-item {% if loop.first %}active{% endif %}" data-sources='{{ lesson.sources | tojson }}' data-title="{{ lesson.title }}" data-poster="{{ course.cover_image or '' }}">
+                <span class="playlist-index">{{ loop.index }}</span>
+                <div>
+                  <div class="playlist-title">{{ lesson.title }}</div>
+                  <div class="muted small">{{ lesson.sources|length }} вариант(а) качества</div>
+                </div>
+              </li>
+              {% endfor %}
+            </ul>
+          </div>
+          {% else %}
+          <p class="muted">В этом курсе пока нет загруженных видео.</p>
+          {% endif %}
+        </article>
+      {% endfor %}
     {% else %}
-      <div class="course-placeholder">Курса пока нет</div>
+      <div class="course-placeholder">Специалист ещё не добавил курс.</div>
     {% endif %}
   </div>
 </section>


### PR DESCRIPTION
## Summary
- add course data models and specialist-only creation flow with cover, preview clip, and playlist uploads
- redesign profile, search, and public profile pages to surface course previews, pricing badges, and Telegram contact info
- add front-end scripts and styles for hover previews, quality switching, and dynamic video field management

## Testing
- python -m compileall app.py templates static/js/app.js

------
https://chatgpt.com/codex/tasks/task_e_68cb3d5e02308320abbee484ef9971be