### PR TITLE
Enable course editing UI and streaming safeguards

### DIFF
--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -74,6 +74,31 @@ input,select,textarea{padding:10px 12px;border:1px solid #cbd5e1;border-radius:1
 .course-empty{text-align:center;padding:32px 16px;border:1px dashed var(--accent);border-radius:16px;color:var(--muted)}
 .profile-note{background:rgba(0,0,0,.04);padding:10px 12px;border-radius:12px;font-size:14px}
 .course-form{display:grid;gap:18px}
+.page-heading{display:grid;gap:8px;margin-bottom:16px}
+.page-heading h1{display:flex;align-items:center;gap:10px;margin:0}
+.course-editor{display:grid;gap:20px}
+.course-form-main{display:grid;grid-template-columns:minmax(0,1fr) 320px;gap:24px;align-items:start}
+@media (max-width:900px){.course-form-main{grid-template-columns:1fr}}
+.course-form-fields{display:grid;gap:16px}
+.course-cover{display:grid;gap:12px}
+.cover-preview{border:1px dashed var(--accent);border-radius:16px;overflow:hidden;min-height:220px;background:rgba(0,0,0,.02);display:grid;place-items:center}
+.cover-preview img{width:100%;height:100%;object-fit:cover}
+.cover-placeholder{color:var(--muted);font-weight:600;text-align:center;padding:24px}
+.section-head{display:flex;align-items:center;justify-content:space-between;gap:12px;flex-wrap:wrap}
+.existing-list{display:grid;gap:12px}
+.existing-card{border:1px solid rgba(0,0,0,.08);border-radius:14px;padding:14px;display:grid;gap:12px;background:rgba(0,0,0,.02)}
+.existing-card-head{display:flex;align-items:center;justify-content:space-between;gap:12px}
+.badge{display:inline-flex;align-items:center;justify-content:center;padding:4px 12px;border-radius:999px;font-weight:700;font-size:13px;background:rgba(27,179,74,.12);color:var(--primary)}
+.badge.accent{background:rgba(27,179,74,.16)}
+.toggle-remove{display:flex;align-items:center;gap:8px;font-weight:600;color:var(--danger)}
+.toggle-remove input{accent-color:var(--danger)}
+.course-manage-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(280px,1fr));gap:18px}
+.course-manage-card{border:1px solid rgba(0,0,0,.08);border-radius:16px;overflow:hidden;background:var(--card);display:grid;gap:0;transition:box-shadow .2s ease}
+.course-manage-card:hover{box-shadow:0 12px 24px rgba(0,0,0,.08)}
+.course-manage-cover .course-thumb{border-radius:0;height:160px}
+.course-manage-body{padding:16px;display:grid;gap:12px}
+.course-manage-actions{display:flex;gap:8px;flex-wrap:wrap}
+.course-manage-actions .btn{flex:1 1 140px;text-align:center}
 .file-pair{align-items:start}
 .videos-block{display:grid;gap:12px}
 .videos-head{display:flex;justify-content:space-between;align-items:center;gap:12px;flex-wrap:wrap}
@@ -88,15 +113,10 @@ input,select,textarea{padding:10px 12px;border:1px solid #cbd5e1;border-radius:1
 .course-detail-meta h3{margin:0}
 .course-detail-meta p{margin:6px 0 0}
 .course-player{display:grid;gap:12px}
-.course-player video{width:100%;border-radius:16px;max-height:380px;background:#000}
+.course-player video{width:100%;border-radius:16px;max-height:420px;background:#000}
+.player-toolbar{display:flex;justify-content:space-between;align-items:center;gap:16px;flex-wrap:wrap}
 .player-controls label{display:flex;gap:8px;align-items:center;font-weight:600}
 .player-controls select{min-width:140px}
-.playlist{list-style:none;margin:0;padding:0;display:grid;gap:8px}
-.playlist-item{display:flex;gap:12px;align-items:center;padding:10px 12px;border-radius:12px;border:1px solid rgba(0,0,0,.12);cursor:pointer;transition:background .2s ease,border .2s ease}
-.playlist-item.active{border-color:var(--primary);background:rgba(27,179,74,.12)}
-.playlist-item:hover{border-color:var(--primary)}
-.playlist-index{width:26px;height:26px;border-radius:999px;background:var(--primary);color:#fff;display:grid;place-items:center;font-weight:700}
-.playlist-title{font-weight:600}
 .course-placeholder{padding:48px 16px;text-align:center;border:1px dashed var(--accent);border-radius:16px;color:var(--muted);font-weight:600}
 .chat-box{display:flex;flex-direction:column;gap:8px}
 .chat-box .messages{flex:1;overflow:auto;max-height:65vh}
@@ -134,6 +154,44 @@ input,select,textarea{padding:10px 12px;border:1px solid #cbd5e1;border-radius:1
 .profile-public{display:grid;grid-template-columns:repeat(auto-fit,minmax(260px,1fr));gap:16px;align-items:start}
 .public-left{display:grid;gap:8px}
 .public-right{display:grid;gap:12px}
+.course-page{display:grid;gap:24px}
+.course-header{display:flex;align-items:center;justify-content:space-between;gap:16px;flex-wrap:wrap}
+.course-author{display:flex;align-items:center;gap:16px}
+.course-author-avatar{width:72px;height:72px;border-radius:999px;object-fit:cover;border:2px solid rgba(0,0,0,.08)}
+.course-header-meta{display:flex;align-items:center;gap:12px;flex-wrap:wrap}
+.price-pill{padding:6px 14px;border-radius:999px;background:var(--primary);color:#fff;font-weight:700;box-shadow:0 10px 20px rgba(0,0,0,.14)}
+.course-layout{display:grid;grid-template-columns:minmax(0,1fr) 320px;gap:24px;align-items:start}
+@media (max-width:1100px){.course-layout{grid-template-columns:1fr}}
+.course-side{display:grid;gap:16px}
+.side-card{border:1px solid rgba(0,0,0,.08);border-radius:16px;padding:16px;background:var(--card);display:grid;gap:12px}
+.side-card.compact{gap:8px}
+.side-courses{display:grid;gap:12px}
+.side-course{display:flex;gap:12px;text-decoration:none;color:var(--text);padding:10px;border-radius:14px;border:1px solid rgba(0,0,0,.08);transition:border .2s ease,background .2s ease}
+.side-course:hover{border-color:var(--primary)}
+.side-course.active{border-color:var(--primary);background:rgba(27,179,74,.08)}
+.side-thumb{width:72px;height:72px;border-radius:12px;background-size:cover;background-position:center;background-color:rgba(0,0,0,.08);flex-shrink:0}
+.side-info{display:grid;gap:4px;align-items:center}
+.side-title{font-weight:600}
+.side-list{list-style:none;margin:0;padding:0;display:grid;gap:6px;font-size:14px}
+.course-hero{display:grid;grid-template-columns:minmax(0,1fr) 320px;gap:24px;align-items:start}
+@media (max-width:900px){.course-hero{grid-template-columns:1fr}}
+.hero-cover{border-radius:16px;overflow:hidden;border:1px solid rgba(0,0,0,.08);background:rgba(0,0,0,.04);min-height:220px;display:grid;place-items:center}
+.hero-cover img{width:100%;height:100%;object-fit:cover}
+.lesson-rail{display:grid;gap:12px;margin-top:16px}
+.lesson-scroll{display:flex;gap:12px;overflow-x:auto;padding-bottom:6px}
+.lesson-card{display:flex;align-items:center;gap:10px;padding:10px 14px;border-radius:12px;border:1px solid rgba(0,0,0,.12);background:var(--card);cursor:pointer;min-width:180px;transition:border .2s ease,background .2s ease;font-weight:600}
+.lesson-card:hover{border-color:var(--primary)}
+.lesson-card.active{border-color:var(--primary);background:rgba(27,179,74,.12)}
+.lesson-index{width:30px;height:30px;border-radius:999px;background:var(--primary);color:#fff;display:grid;place-items:center;font-weight:700}
+.accordion-group{display:grid;gap:12px;margin-top:16px}
+.accordion-item{border:1px solid rgba(0,0,0,.08);border-radius:12px;background:var(--card);overflow:hidden}
+.accordion-toggle{width:100%;background:transparent;border:none;text-align:left;padding:12px 16px;font-weight:700;display:flex;align-items:center;justify-content:space-between;cursor:pointer;color:var(--text)}
+.accordion-toggle::after{content:'+';font-weight:700;transition:transform .2s ease}
+.accordion-item.open .accordion-toggle::after{transform:rotate(45deg)}
+.accordion-content{max-height:0;overflow:hidden;transition:max-height .25s ease;padding:0 16px}
+.accordion-item.open .accordion-content{max-height:520px;padding:0 16px 16px}
+.accordion-content p{margin:12px 0 0}
+.about-list{list-style:none;margin:0;padding:0;display:grid;gap:6px;font-size:14px}
 html[data-theme="dark"] .nav-link:hover{background:rgba(255,255,255,.08)}
 html[data-theme="dark"] .profile-tabs .tab{background:rgba(255,255,255,.08)}
 html[data-theme="dark"] .profile-tabs .tab:hover{background:rgba(255,255,255,.14)}
@@ -141,4 +199,10 @@ html[data-theme="dark"] .course-card-mini{background:rgba(255,255,255,.04);borde
 html[data-theme="dark"] .course-thumb{border-color:rgba(255,255,255,.1)}
 html[data-theme="dark"] .profile-note{background:rgba(255,255,255,.06)}
 html[data-theme="dark"] .video-item{background:rgba(255,255,255,.04);border-color:rgba(255,255,255,.12)}
-html[data-theme="dark"] .playlist-item{border-color:rgba(255,255,255,.12)}
+html[data-theme="dark"] .existing-card{background:rgba(255,255,255,.04);border-color:rgba(255,255,255,.12)}
+html[data-theme="dark"] .side-card{border-color:rgba(255,255,255,.12);background:rgba(255,255,255,.04)}
+html[data-theme="dark"] .side-course{border-color:rgba(255,255,255,.12);background:rgba(255,255,255,.02)}
+html[data-theme="dark"] .side-course.active{background:rgba(57,255,20,.12)}
+html[data-theme="dark"] .accordion-item{border-color:rgba(255,255,255,.12);background:rgba(255,255,255,.04)}
+html[data-theme="dark"] .lesson-card{background:rgba(255,255,255,.02);border-color:rgba(255,255,255,.12)}
+html[data-theme="dark"] .lesson-card.active{background:rgba(57,255,20,.12);border-color:var(--primary)}

--- a/static/img/no-download.svg
+++ b/static/img/no-download.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 600">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#0a220f"/>
+      <stop offset="1" stop-color="#14552a"/>
+    </linearGradient>
+  </defs>
+  <rect width="800" height="600" fill="url(#bg)" rx="28"/>
+  <g fill="#1bb34a" font-family="'Segoe UI', 'DejaVu Sans', sans-serif" text-anchor="middle">
+    <text x="400" y="270" font-size="54" font-weight="700">Материалы защищены</text>
+    <text x="400" y="340" font-size="34" fill="#ffffff">Загрузка недоступна</text>
+  </g>
+  <circle cx="400" cy="430" r="70" fill="none" stroke="#1bb34a" stroke-width="10"/>
+  <path d="M360 470 400 430 440 470" stroke="#1bb34a" stroke-width="12" stroke-linecap="round" fill="none"/>
+  <path d="M400 410v-70" stroke="#1bb34a" stroke-width="12" stroke-linecap="round"/>
+</svg>

--- a/templates/course_form.html
+++ b/templates/course_form.html
@@ -1,75 +1,128 @@
 {% extends "base.html" %}
-{% block title %}Добавить курс{% endblock %}
+{% set page_title = 'Редактировать интенсив' if form.is_edit else 'Добавить интенсив' %}
+{% block title %}{{ page_title }}{% endblock %}
 {% block content %}
-<h1><span class="icon icon-profile"></span>Добавить курс</h1>
-<form class="card course-form" method="post" enctype="multipart/form-data" id="courseForm">
-  <div class="grid-2 stack-sm">
-    <label class="field">
-      <span>Заголовок *</span>
-      <input name="title" value="{{ form.title }}" placeholder="Например, React с нуля" required>
-    </label>
-    <label class="field">
-      <span>Цена интенсива *</span>
-      <input name="price" value="{{ form.price }}" placeholder="3500" inputmode="decimal" required>
-    </label>
-    <label class="field">
-      <span>Предмет</span>
-      <input name="subject" value="{{ form.subject }}" placeholder="Направление или предмет">
-    </label>
-    <label class="field">
-      <span>Тема (можно пропустить)</span>
-      <input name="topic" value="{{ form.topic }}" placeholder="Тема курса">
-    </label>
-  </div>
-  <label class="field">
-    <span>Описание</span>
-    <textarea name="description" rows="4" placeholder="Расскажите, чему научится студент и кому подойдёт курс">{{ form.description }}</textarea>
-  </label>
-  <div class="grid-2 stack-sm file-pair">
-    <label class="field file-field">
-      <span>Изображение интенсива *</span>
-      <input type="file" name="cover_image" accept="image/*" required>
-      <small class="muted">Добавьте яркую обложку, которая появится в поиске.</small>
-    </label>
-    <label class="field file-field">
-      <span>Видео-превью (необязательно)</span>
-      <input type="file" name="preview_clip" accept="video/*">
-      <small class="muted">Короткое превью, которое воспроизводится при наведении.</small>
-    </label>
-  </div>
-  <div class="videos-block" data-video-list>
-    <div class="videos-head">
-      <h3>Видео материалы</h3>
-      <button class="btn outline" type="button" data-video-add>Добавить видео</button>
-    </div>
-    <p class="muted small">Если видео весит слишком много, разделите его на несколько частей и загрузите их отдельно.</p>
-    <div class="video-items">
-      {% for meta in form.video_meta %}
-      <div class="video-item" data-video-item>
+<section class="course-editor">
+  <header class="page-heading">
+    <h1><span class="icon icon-profile"></span>{{ page_title }}</h1>
+    <p class="muted">Соберите структуру интенсива, загрузите материалы и добавьте обложку, чтобы ученикам было проще выбрать вас.</p>
+  </header>
+  <form class="card course-form" method="post" enctype="multipart/form-data" id="courseForm">
+    <div class="course-form-main">
+      <div class="course-form-fields">
         <div class="grid-2 stack-sm">
           <label class="field">
-            <span>Название видео</span>
-            <input name="video_title[]" value="{{ meta.title }}" placeholder="Урок {{ loop.index }}">
+            <span>Заголовок *</span>
+            <input name="title" value="{{ form.title }}" placeholder="Например, Интенсив по подготовке к ЕГЭ" required>
           </label>
           <label class="field">
-            <span>Качество</span>
-            <input name="video_quality[]" value="{{ meta.quality }}" placeholder="Например, 1080p">
+            <span>Цена интенсива *</span>
+            <input name="price" value="{{ form.price }}" placeholder="3500" inputmode="decimal" required>
+          </label>
+          <label class="field">
+            <span>Предмет</span>
+            <input name="subject" value="{{ form.subject }}" placeholder="Направление или предмет">
+          </label>
+          <label class="field">
+            <span>Тема (необязательно)</span>
+            <input name="topic" value="{{ form.topic }}" placeholder="Основная тема">
           </label>
         </div>
-        <label class="field file-field">
-          <span>Файл</span>
-          <input type="file" name="video_file[]" accept="video/*" {% if loop.first %}required{% endif %}>
-        </label>
-        <button class="remove-video" type="button" data-video-remove>Удалить видео</button>
       </div>
-      {% endfor %}
+      <div class="course-cover">
+        <div class="cover-preview">
+          {% if form.cover_preview %}
+          <img src="{{ form.cover_preview }}" alt="Обложка интенсива">
+          {% else %}
+          <div class="cover-placeholder">Превью появится после загрузки</div>
+          {% endif %}
+        </div>
+        <label class="field file-field">
+          <span>Изображение интенсива {% if not form.is_edit %}*{% endif %}</span>
+          <input type="file" name="cover_image" accept="image/*" {% if not form.is_edit %}required{% endif %}>
+          <small class="muted">Форматы: png, jpg, jpeg, gif, webp. Обложка отображается в поиске и на странице интенсива.</small>
+        </label>
+      </div>
     </div>
-  </div>
-  <div class="form-actions">
-    <a class="btn outline" href="{{ url_for('profile', tab='course') }}">Отмена</a>
-    <button class="btn strong" type="submit">Сохранить курс</button>
-  </div>
-</form>
+    <label class="field">
+      <span>Описание</span>
+      <textarea name="description" rows="4" placeholder="Опишите программу, пользу и формат занятий">{{ form.description }}</textarea>
+    </label>
+
+    {% if form.is_edit and form.existing_videos %}
+    <section class="existing-videos" data-existing-list>
+      <div class="section-head">
+        <h3>Список уроков</h3>
+        <p class="muted small">Настройте порядок, названия и отметьте материалы, которые нужно удалить.</p>
+      </div>
+      <div class="existing-list">
+        {% for video in form.existing_videos %}
+        <article class="existing-card">
+          <div class="existing-card-head">
+            <span class="badge">Урок {{ loop.index }}</span>
+            <label class="toggle-remove">
+              <input type="checkbox" name="remove_video_ids[]" value="{{ video.id }}" {% if video.marked %}checked{% endif %}>
+              <span>Удалить</span>
+            </label>
+          </div>
+          <div class="grid-3 stack-sm">
+            <label class="field">
+              <span>Название</span>
+              <input name="existing_title_{{ video.id }}" value="{{ video.title }}" placeholder="Урок {{ loop.index }}">
+            </label>
+            <label class="field">
+              <span>Качество</span>
+              <input name="existing_quality_{{ video.id }}" value="{{ video.quality }}" placeholder="Например, 1080p">
+            </label>
+            <label class="field">
+              <span>Порядок</span>
+              <input type="number" name="existing_order_{{ video.id }}" value="{{ video.order if video.order is not none else loop.index0 }}" min="0">
+            </label>
+          </div>
+        </article>
+        {% endfor %}
+      </div>
+    </section>
+    {% endif %}
+
+    <section class="videos-block" data-video-list data-edit-mode="{{ '1' if form.is_edit else '0' }}">
+      <div class="videos-head">
+        <div>
+          <h3>Новые материалы</h3>
+          <p class="muted small">При необходимости добавьте дополнительные видео. Они появятся в конце плейлиста.</p>
+        </div>
+        <button class="btn outline" type="button" data-video-add>Добавить файл</button>
+      </div>
+      <div class="video-items">
+        {% for meta in form.video_meta %}
+        <div class="video-item" data-video-item>
+          <div class="grid-2 stack-sm">
+            <label class="field">
+              <span>Название видео</span>
+              <input name="video_title[]" value="{{ meta.title }}" placeholder="Новый урок">
+            </label>
+            <label class="field">
+              <span>Качество</span>
+              <input name="video_quality[]" value="{{ meta.quality }}" placeholder="Например, 720p">
+            </label>
+          </div>
+          <label class="field file-field">
+            <span>Файл</span>
+            <input type="file" name="video_file[]" accept="video/*">
+          </label>
+          <button class="remove-video" type="button" data-video-remove>Убрать блок</button>
+        </div>
+        {% endfor %}
+      </div>
+    </section>
+
+    <div class="form-actions">
+      <a class="btn outline" href="{{ url_for('profile', tab='course') }}">Отмена</a>
+      <button class="btn strong" type="submit">{{ 'Сохранить изменения' if form.is_edit else 'Опубликовать интенсив' }}</button>
+    </div>
+  </form>
+</section>
+
 <template id="videoItemTemplate">
   <div class="video-item" data-video-item>
     <div class="grid-2 stack-sm">
@@ -84,9 +137,9 @@
     </div>
     <label class="field file-field">
       <span>Файл</span>
-      <input type="file" name="video_file[]" accept="video/*" required>
+      <input type="file" name="video_file[]" accept="video/*">
     </label>
-    <button class="remove-video" type="button" data-video-remove>Удалить видео</button>
+    <button class="remove-video" type="button" data-video-remove>Убрать блок</button>
   </div>
 </template>
 {% endblock %}

--- a/templates/profile.html
+++ b/templates/profile.html
@@ -75,28 +75,32 @@
   <div class="course-manage-header">
     <div>
       <h3>Мои интенсивы</h3>
-      <p class="muted">Добавьте курс с подробным описанием, видео и обложкой.</p>
+      <p class="muted">Редактируйте существующие плейлисты и добавляйте новые материалы в пару кликов.</p>
     </div>
     <a class="btn strong" href="{{ url_for('course_create') }}">Добавить курс</a>
   </div>
   {% if courses %}
-  <div class="course-grid">
+  <div class="course-manage-grid">
     {% for item in courses %}
       {% set course = item.course %}
-      <div class="course-card-mini">
-        <div class="course-thumb" {% if course.cover_image %}style="background-image:url('{{ course.cover_image }}')"{% endif %}>
-          {% if item.video_count %}
-          <span class="course-count">{{ item.video_count }} видео</span>
-          {% endif %}
-          {% if course.price is not none %}
-          <span class="price-tag">{{ format_price(course.price) }}</span>
-          {% endif %}
+      <article class="course-manage-card">
+        <a class="course-manage-cover" href="{{ item.public_url }}" target="_blank">
+          <div class="course-thumb" {% if course.cover_image %}style="background-image:url('{{ course.cover_image }}')"{% endif %}>
+            {% if item.video_count %}<span class="course-count">{{ item.video_count }} видео</span>{% endif %}
+            {% if course.price is not none %}<span class="price-tag">{{ format_price(course.price) }}</span>{% endif %}
+          </div>
+        </a>
+        <div class="course-manage-body">
+          <div class="course-manage-info">
+            <h4>{{ course.title }}</h4>
+            <p class="muted">{{ course.subject or 'Без предмета' }}{% if course.topic %} · {{ course.topic }}{% endif %}</p>
+          </div>
+          <div class="course-manage-actions">
+            <a class="btn strong" href="{{ item.edit_url }}">Редактировать</a>
+            <a class="btn outline" href="{{ item.public_url }}" target="_blank">Открыть</a>
+          </div>
         </div>
-        <div class="course-info">
-          <h4>{{ course.title }}</h4>
-          <p class="muted">{{ course.subject or 'Без предмета' }}{% if course.topic %} · {{ course.topic }}{% endif %}</p>
-        </div>
-      </div>
+      </article>
     {% endfor %}
   </div>
   {% else %}
@@ -123,7 +127,7 @@
     <div class="course-grid">
       {% for item in courses %}
         {% set course = item.course %}
-        <div class="course-card-mini compact">
+        <a class="course-card-mini compact" href="{{ item.public_url }}" target="_blank">
           <div class="course-thumb" {% if course.cover_image %}style="background-image:url('{{ course.cover_image }}')"{% endif %}>
             {% if item.video_count %}<span class="course-count">{{ item.video_count }} видео</span>{% endif %}
             {% if course.price is not none %}<span class="price-tag">{{ format_price(course.price) }}</span>{% endif %}
@@ -132,7 +136,7 @@
             <h4>{{ course.title }}</h4>
             <p class="muted">{{ course.subject or 'Без предмета' }}{% if course.topic %} · {{ course.topic }}{% endif %}</p>
           </div>
-        </div>
+        </a>
       {% endfor %}
     </div>
     {% else %}

--- a/templates/search.html
+++ b/templates/search.html
@@ -7,56 +7,52 @@
   <button class="btn strong" type="submit">Найти</button>
 </form>
 <div class="grid-cards">
-  {% for p in people %}
-  {% set preview_course = p.courses|last %}
-  <a class="card person course-card" href="{{ url_for('public_profile', user_id=p.id) }}">
+  {% for entry in results %}
+  {% set person = entry.person %}
+  {% set course = entry.course %}
+  <a class="card person course-card" href="{{ url_for('public_profile', user_id=person.id, course_id=course.id if course else None) }}">
     <div class="course-card-header">
-      <div class="course-thumb" {% if preview_course and preview_course.cover_image %}style="background-image:url('{{ preview_course.cover_image }}')"{% endif %}>
-        {% if not preview_course or not preview_course.cover_image %}
-        <span class="course-thumb-placeholder">Превью появится после публикации</span>
+      <div class="course-thumb" {% if course and course.cover_image %}style="background-image:url('{{ course.cover_image }}')"{% endif %}>
+        {% if not course or not course.cover_image %}
+        <span class="course-thumb-placeholder">Изображение появится после загрузки</span>
         {% endif %}
-        {% if preview_course and preview_course.preview_clip %}
-        <div class="hover-video" data-preview-hover>
-          <video src="{{ preview_course.preview_clip }}" muted loop preload="metadata" {% if preview_course.cover_image %}poster="{{ preview_course.cover_image }}"{% endif %}></video>
-        </div>
-        {% endif %}
-        {% if preview_course and preview_course.videos %}
-        <span class="course-count">{{ preview_course.videos|length }} видео</span>
+        {% if course and course.videos %}
+        <span class="course-count">{{ course.videos|length }} видео</span>
         {% endif %}
       </div>
-      {% if preview_course and preview_course.price is not none %}
-      <span class="price-tag">{{ format_price(preview_course.price) }}</span>
+      {% if course and course.price is not none %}
+      <span class="price-tag">{{ format_price(course.price) }}</span>
       {% endif %}
     </div>
     <div class="person-row">
-      <img class="avatar-mini" src="{{ avatar_url(p) }}" alt="{{ p.nickname or p.first_name }}">
+      <img class="avatar-mini" src="{{ avatar_url(person) }}" alt="{{ person.nickname or person.first_name }}">
       <div>
-        <div class="p-name">{{ p.first_name or 'Без имени' }} {{ p.last_name or '' }}</div>
-        <div class="muted">@{{ p.nickname or 'без_ника' }}</div>
+        <div class="p-name">{{ person.first_name or 'Без имени' }} {{ person.last_name or '' }}</div>
+        <div class="muted">@{{ person.nickname or 'без_ника' }}</div>
       </div>
     </div>
     <div class="tags">
-      {% if preview_course %}
-        {{ preview_course.subject or 'Без предмета' }}{% if preview_course.topic %} · {{ preview_course.topic }}{% endif %}
+      {% if course %}
+        {{ course.subject or 'Без предмета' }}{% if course.topic %} · {{ course.topic }}{% endif %}
       {% else %}
-        {{ p.specialist.keywords if p.specialist else (p.student.looking_for if p.student else '') }}
+        {{ person.specialist.keywords if person.specialist else (person.student.looking_for if person.student else '') }}
       {% endif %}
     </div>
     <div class="preview-info">
-      {% if preview_course %}
-      <div class="preview-title">Превью курса</div>
-      <div class="muted small">{{ preview_course.title }}</div>
+      {% if course %}
+      <div class="preview-title">{{ course.title }}</div>
+      <div class="muted small">Интенсив специалиста {{ person.first_name or person.nickname or person.email }}</div>
       {% else %}
-      <div class="muted small">Специалист ещё не добавил курс.</div>
+      <div class="muted small">Специалист ещё не опубликовал интенсив.</div>
       {% endif %}
     </div>
     <div class="person-actions">
-      <span>Перейти к профилю</span>
+      <span>Перейти к интенсиву</span>
       <svg class="icon" viewBox="0 0 24 24" aria-hidden="true"><path d="m9 5 7 7-7 7-1.41-1.41L13.17 12 7.59 6.41 9 5Z"/></svg>
     </div>
   </a>
   {% endfor %}
-  {% if not people %}
+  {% if not results %}
   <div class="card muted">По вашему запросу ничего не найдено.</div>
   {% endif %}
 </div>

--- a/templates/user_public.html
+++ b/templates/user_public.html
@@ -1,82 +1,145 @@
 {% extends "base.html" %}
 {% block title %}Профиль пользователя{% endblock %}
 {% block content %}
-<h1><span class="icon icon-profile"></span>{{ person.first_name or 'Профиль' }} {{ person.last_name or '' }}</h1>
-<section class="profile-public">
-  <div class="card public-left">
-    <img class="avatar" src="{{ avatar }}" alt="avatar">
-    <h2>О себе</h2>
-    <p><strong>@{{ person.nickname or 'без_ника' }}</strong></p>
-    <p>Роль: {{ 'Специалист' if person.role=='specialist' else 'Ученик' }}</p>
-    <p>Имя: {{ person.first_name or '—' }}</p>
-    <p>Фамилия: {{ person.last_name or '—' }}</p>
-    <p>Возраст: {{ person.age or '—' }}</p>
-    <p>Образование: {{ person.education or '—' }}</p>
-    <p>Год выпуска: {{ person.graduation_year or '—' }}</p>
-    <p>Телеграм: {{ person.telegram or '—' }}</p>
-  </div>
-  <div class="card public-right">
-    <h2>Курсы</h2>
-    {% if courses %}
-      {% for data in courses %}
-        {% set course = data.course %}
-        <article class="course-detail" data-course-player>
-          <header class="course-detail-header">
-            <div class="course-detail-cover" {% if course.cover_image %}style="background-image:url('{{ course.cover_image }}')"{% endif %}>
-              {% if data.video_total %}
-              <span class="course-count">{{ data.video_total }} видео</span>
-              {% endif %}
-              {% if course.price is not none %}
-              <span class="price-tag">{{ format_price(course.price) }}</span>
-              {% endif %}
-              {% if course.preview_clip %}
-              <div class="hover-video" data-preview-hover>
-                <video src="{{ course.preview_clip }}" muted loop preload="metadata" {% if course.cover_image %}poster="{{ course.cover_image }}"{% endif %}></video>
-              </div>
-              {% endif %}
-            </div>
-            <div class="course-detail-meta">
-              <h3>{{ course.title }}</h3>
-              <div class="muted">{{ course.subject or 'Без предмета' }}{% if course.topic %} · {{ course.topic }}{% endif %}</div>
-              {% if course.description %}<p>{{ course.description }}</p>{% endif %}
-            </div>
-          </header>
-          {% if data.lessons %}
-          <div class="course-player" data-player>
-            <video controls preload="metadata" data-video {% if course.cover_image %}poster="{{ course.cover_image }}"{% endif %}>
-              {% set first_lesson = data.lessons[0] %}
-              {% set first_source = first_lesson.sources[0] %}
-              <source src="{{ first_source.src }}">
-            </video>
-            <div class="player-controls">
-              <label>Качество
-                <select data-quality-select>
-                  {% for source in first_lesson.sources %}
-                  <option value="{{ source.src }}">{{ source.quality }}</option>
-                  {% endfor %}
-                </select>
-              </label>
-            </div>
-            <ul class="playlist" data-playlist>
-              {% for lesson in data.lessons %}
-              <li class="playlist-item {% if loop.first %}active{% endif %}" data-sources='{{ lesson.sources | tojson }}' data-title="{{ lesson.title }}" data-poster="{{ course.cover_image or '' }}">
-                <span class="playlist-index">{{ loop.index }}</span>
-                <div>
-                  <div class="playlist-title">{{ lesson.title }}</div>
-                  <div class="muted small">{{ lesson.sources|length }} вариант(а) качества</div>
-                </div>
-              </li>
-              {% endfor %}
-            </ul>
-          </div>
-          {% else %}
-          <p class="muted">В этом курсе пока нет загруженных видео.</p>
-          {% endif %}
-        </article>
-      {% endfor %}
-    {% else %}
-      <div class="course-placeholder">Специалист ещё не добавил курс.</div>
+<section class="course-page">
+  <header class="course-header">
+    <div class="course-author">
+      <img class="course-author-avatar" src="{{ avatar }}" alt="Аватар {{ person.first_name or person.nickname or 'пользователя' }}">
+      <div>
+        <h1>{{ person.first_name or 'Профиль' }} {{ person.last_name or '' }}</h1>
+        <div class="muted">@{{ person.nickname or 'без_ника' }} · {{ 'Специалист' if person.role=='specialist' else 'Ученик' }}</div>
+      </div>
+    </div>
+    {% if selected_course %}
+    <div class="course-header-meta">
+      {% set course = selected_course.course %}
+      <div class="badge accent">{{ course.subject or 'Без предмета' }}{% if course.topic %} · {{ course.topic }}{% endif %}</div>
+      {% if course.price is not none %}
+      <div class="price-pill">{{ format_price(course.price) }}</div>
+      {% endif %}
+    </div>
     {% endif %}
+  </header>
+
+  <div class="course-layout">
+    <div class="course-main">
+      {% if selected_course %}
+      {% set course = selected_course.course %}
+      {% set first_lesson = selected_course.lessons[0] if selected_course.lessons else None %}
+      {% set first_source = first_lesson.sources[0] if first_lesson else None %}
+      <div class="course-hero">
+        <div class="course-hero-left">
+          <h2>{{ course.title }}</h2>
+          <p class="muted">Последнее обновление · {{ (course.created_at.strftime('%d.%m.%Y') if course.created_at else '') }}</p>
+          <div class="accordion-group" data-accordion-group>
+            <div class="accordion-item open" data-accordion-item>
+              <button class="accordion-toggle" type="button">Описание</button>
+              <div class="accordion-content">
+                {% if course.description %}
+                <p>{{ course.description }}</p>
+                {% else %}
+                <p class="muted">Автор ещё не добавил описание к интенсиву.</p>
+                {% endif %}
+              </div>
+            </div>
+            <div class="accordion-item" data-accordion-item>
+              <button class="accordion-toggle" type="button">О специалисте</button>
+              <div class="accordion-content">
+                <ul class="about-list">
+                  <li><strong>Имя:</strong> {{ person.first_name or '—' }} {{ person.last_name or '' }}</li>
+                  <li><strong>Возраст:</strong> {{ person.age or '—' }}</li>
+                  <li><strong>Образование:</strong> {{ person.education or '—' }}</li>
+                  <li><strong>Год выпуска:</strong> {{ person.graduation_year or '—' }}</li>
+                  <li><strong>Ключевые навыки:</strong> {{ person.specialist.keywords if person.specialist else '—' }}</li>
+                  <li><strong>Telegram:</strong> {{ person.telegram or '—' }}</li>
+                </ul>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="course-hero-right">
+          <div class="hero-cover">
+            {% if course.cover_image %}
+            <img src="{{ course.cover_image }}" alt="Обложка {{ course.title }}">
+            {% else %}
+            <div class="cover-placeholder">Изображение появится после загрузки</div>
+            {% endif %}
+          </div>
+        </div>
+      </div>
+
+      <div class="course-player" data-player>
+        <video controls controlsList="nodownload" preload="metadata" data-video oncontextmenu="return false;">
+          {% if first_source %}
+          <source src="{{ first_source.src }}">
+          {% endif %}
+        </video>
+        <div class="player-toolbar">
+          <div class="player-controls">
+            {% if first_lesson %}
+            <label>Качество
+              <select data-quality-select>
+                {% for source in first_lesson.sources %}
+                <option value="{{ source.src }}">{{ source.quality }}</option>
+                {% endfor %}
+              </select>
+            </label>
+            {% endif %}
+          </div>
+          <div class="player-actions">
+            <a class="btn outline" data-download-target {% if first_source %}href="{{ first_source.download }}"{% else %}href="#"{% endif %} target="_blank" rel="noopener">Скачать материалы</a>
+          </div>
+        </div>
+      </div>
+
+      {% if selected_course.lessons %}
+      <div class="lesson-rail" data-lesson-rail>
+        <h3>Все уроки</h3>
+        <div class="lesson-scroll">
+          {% for lesson in selected_course.lessons %}
+          <button class="lesson-card {% if loop.first %}active{% endif %}" type="button" data-sources='{{ lesson.sources | tojson }}'>
+            <span class="lesson-index">{{ loop.index }}</span>
+            <span class="lesson-title">{{ lesson.title }}</span>
+          </button>
+          {% endfor %}
+        </div>
+      </div>
+      {% else %}
+      <div class="course-placeholder">В этом интенсиве пока нет загруженных видео.</div>
+      {% endif %}
+      {% else %}
+      <div class="course-placeholder">Специалист ещё не добавил интенсив.</div>
+      {% endif %}
+    </div>
+
+    <aside class="course-side">
+      <div class="side-card">
+        <h3>Интенсивы специалиста</h3>
+        {% if courses %}
+        <div class="side-courses">
+          {% for payload in courses %}
+          {% set course = payload.course %}
+          <a class="side-course {% if selected_course and selected_course.course.id == course.id %}active{% endif %}" href="{{ url_for('public_profile', user_id=person.id, course_id=course.id) }}">
+            <div class="side-thumb" {% if course.cover_image %}style="background-image:url('{{ course.cover_image }}')"{% endif %}></div>
+            <div class="side-info">
+              <div class="side-title">{{ course.title }}</div>
+              <div class="muted small">{{ course.subject or 'Без предмета' }}{% if course.topic %} · {{ course.topic }}{% endif %}</div>
+            </div>
+          </a>
+          {% endfor %}
+        </div>
+        {% else %}
+        <p class="muted small">Здесь появятся опубликованные интенсивы.</p>
+        {% endif %}
+      </div>
+      <div class="side-card compact">
+        <h3>Контакты</h3>
+        <ul class="side-list">
+          <li><strong>Telegram:</strong> {{ person.telegram or '—' }}</li>
+          <li><strong>Email:</strong> {{ person.email }}</li>
+        </ul>
+      </div>
+    </aside>
   </div>
 </section>
 {% endblock %}


### PR DESCRIPTION
## Summary
- allow specialists to revisit and update their intensives, including playlist adjustments and cover replacement
- refresh the course management, search, and public viewing pages with organized layouts and consistent styling
- protect uploaded videos by routing playback through guarded endpoints, disabling downloads, and serving a branded decoy asset

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68cb49fe55b0832099475a3ddcffb601